### PR TITLE
Update supply code for atoms

### DIFF
--- a/src/atoms.py
+++ b/src/atoms.py
@@ -1,0 +1,85 @@
+from functools import reduce
+from typing import Iterable, NamedTuple
+
+# Added SupplyAtom type. Defined as a NamedTuple
+class SupplyAtom(NamedTuple):
+    identifier: str
+    description: str
+    
+    # only consider the identifier field when hashing or comparing
+    def __hash__(self) -> int:
+        return self.identifier.__hash__()
+    def __eq__(self, __o: object) -> bool:
+        return self.identifier == __o.identifier
+
+# Product atoms
+fabricMask = SupplyAtom("QH00001", "Fabric Mask")
+
+# BOM atoms
+nwpp = SupplyAtom("QH00002", "Non-woven Polypropylene bag")
+biasTape = SupplyAtom("Q4902580", "Bias tape")
+tinTie = SupplyAtom("QH00003", "Coffee tin tie")
+pipeCleaner = SupplyAtom("Q3355092", "pipe cleaners")
+
+# Tool Atoms
+sewingMachine = SupplyAtom("Q49013", "Sewing machine")
+scissors = SupplyAtom("Q40847", "Scissors")
+pins = SupplyAtom("Q111591519", "Pins")
+measuringTape = SupplyAtom("Q107196205", "Measuring Tape")
+
+# BOM Output Atoms
+scrapFabric = SupplyAtom("Q1378670", "Scrap Fabric")
+
+# SupplyDesign maps to the original Supply and OKH types
+# Note, this type currently it lacks the `eqn` field needed for cost calculation
+class SupplyDesign(NamedTuple):
+    product: SupplyAtom
+    bom: frozenset[SupplyAtom]
+    tools: frozenset[SupplyAtom]
+    bomOutputs: frozenset[SupplyAtom]
+
+    @property
+    def outputs(self):
+        return frozenset([self.product]).union(self.bomOutputs)
+
+    @staticmethod
+    def create(product: SupplyAtom, bom: Iterable[SupplyAtom], tools: Iterable[SupplyAtom], bomOutput: Iterable[SupplyAtom]):
+        return SupplyDesign(product, frozenset(bom), frozenset(tools), frozenset(bomOutput))
+
+maskDesign = SupplyDesign.create(
+    fabricMask, 
+    [nwpp, biasTape, tinTie, pipeCleaner], 
+    [sewingMachine, scissors, pins, scissors],
+    [scrapFabric])
+
+# SupplyNetwork maps to the original SupplyNetwork type
+# it stores supplies in a set instead of a list since we aren't tracking ammounts yet
+# Also, it also stores a set of available tools as well as available supplies
+class SupplyNetwork:
+    def __init__(self, name: str, supplies: Iterable[SupplyAtom], tools: Iterable[SupplyAtom]) -> None:
+        self.name = name
+        self.supplies = set(supplies)
+        self.tools = set(tools)
+    def addSupply(self, item: SupplyAtom):
+        self.supplies.add(item)
+    def removeSupply(self, item: SupplyAtom):
+        self.supplies.remove(item)
+    def addTool(self, item: SupplyAtom):
+        self.tools.add(item)
+    def removeSupply(self, item: SupplyAtom):
+        self.tools.remove(item)
+
+    @staticmethod
+    def union(a: 'SupplyNetwork', b: 'SupplyNetwork'):
+        return SupplyNetwork(
+            a.name + "|" + b.name,
+            a.supplies.union(b.supplies),
+            a.tools.union(b.tools)) 
+    
+    # goodTypes - not sure what to do with this
+    # oneSUpply - doesn't appear to be used yet
+    # allSupplies - doesn't appear to be used yet
+
+jamesSpace = SupplyNetwork("James Maker Space", 
+    [nwpp, biasTape, tinTie, pipeCleaner], 
+    [sewingMachine, scissors, pins, measuringTape])

--- a/src/atoms.py
+++ b/src/atoms.py
@@ -21,7 +21,6 @@ class Supplier(NamedTuple):
     def create(name: str, supplies: Iterable[SupplyAtom]):
         return Supplier(name, frozenset(supplies))
 
-
 class Maker(NamedTuple):
     name: str
     tools: frozenset[SupplyAtom]
@@ -94,11 +93,11 @@ class SupplyProblemSpace(NamedTuple):
                     yield SupplierSupplyTree(product, supplier)
         for design in self.designs:
             if design.product == product:
-                foo = map(lambda b: self.query(b), design.bom)
-                inputs = frozenset(itertools.chain.from_iterable(foo))
+                inputTrees = map(lambda b: self.query(b), design.bom)
+                inputTreeSet = frozenset(itertools.chain.from_iterable(inputTrees))
                 for maker in self.makers:
                     if maker.compatible(design.tools):
-                        yield MakerSupplyTree(product, design, maker, inputs)
+                        yield MakerSupplyTree(product, design, maker, inputTreeSet)
 
 
 # Mask Sample


### PR DESCRIPTION
fixes #28

Note, this PR introduces new atom-enabled supply chain code in atoms.py without touching the existing code. We should remove the older code once we complete the end-to-end scenario (i.e. finish #29 and #30)