### PR TITLE
Cleanup and avoid warnings for poetry install

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After installing Poetry, install the `okf-library` as follows:
 
 Then, the dependencies (described in `poetry.lock`) can be installed as follows:
 
-`poetry install`
+`poetry install --no-root`
 
 Finally, run code as follows:
 

--- a/src/okf.py
+++ b/src/okf.py
@@ -93,8 +93,6 @@ class OKF:
 # Useful files are:
 # okh-manifest-surge-english.yml
 
-
-import yamale
 def slurpOKH(filename):
 #    schema = yamale.make_schema('./schema.yaml')
     okh = yamale.make_data(filename)

--- a/src/pd_sc.py
+++ b/src/pd_sc.py
@@ -25,6 +25,10 @@ from sympy import *
 
 import pprint
 from supply import *
+from okf import *
+from stage_graph import *
+import unittest
+import copy
 
 # A vary basic set of supplies...
 
@@ -102,7 +106,7 @@ for st in list(SupplyProblem("chair",a).completeSupplyTrees()):
 print(SupplyProblem("chair",a).optimalCompleteSupplyTreeByPrice(price_map)[0])
 
 
-from okf import *
+
 
 okh1 = OKH("SurgeMask",["mask"],["NWPP","coffee_tin_ties","fabric_ties"],["sewing_machine"],"no eqn yet")
 
@@ -119,7 +123,7 @@ combined = unionSupplyNetworks(a,okf_sn)
 for st in list(SupplyProblem("mask",okf_sn)):
     print(st)
 
-from stage_graph import *
+
 
 sgc = StageGraph("chair",sx)
 sgc.assertSupplyStatus("seat_1",StageStatus.FAILED)
@@ -144,8 +148,7 @@ print(sgc)
 
 o1 = Order("chair",sx)
 
-import unittest
-import copy
+
 # our basic goal here is to create a bifurcated supply network:
 # C = A union B, where A intersect B = 0.
 # For every good, we want to show:
@@ -262,7 +265,7 @@ def getKnownOKHs(okhAlphaDir = "../okf-library/alpha/okh/"):
 
 
 
-import copy
+
 scratched = copy.deepcopy(a)
 scratched.scratch("leg_1")
 for s in scratched.supplies:

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -30,11 +30,11 @@
 
 from supply import *
 from enum import Enum
+
 class StageStatus(Enum):
     OPEN = 0
     SUCCEEDED  = 1
     FAILED = 2
-
 
 class StageGraph:
     def __init__(self,good,supplyTree):


### PR DESCRIPTION
This is a minor PR to move import statements to the top of file in accordance with PEP8. See this [stack overflow post](https://stackoverflow.com/questions/128478/should-import-statements-always-be-at-the-top-of-a-module) for more info.

Additionally, when I ran `poetry install` I got the error "error no element to install", which is fixed by adding the flag `--no-root` to the command, like: `poetry install --no-root`
[This stackoverflow issue](https://stackoverflow.com/questions/75397736/poetry-install-on-an-existing-project-error-does-not-contain-any-element) for more details.